### PR TITLE
Use Orchestrion for tracing

### DIFF
--- a/.container/Dockerfile
+++ b/.container/Dockerfile
@@ -9,9 +9,13 @@ WORKDIR /app
 
 COPY . ./
 
-RUN go mod verify && go mod vendor
 
-RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -ldflags "-X github.com/SneaksAndData/nexus-core/pkg/buildmeta.AppVersion=$APPVERSION -X github.com/SneaksAndData/nexus-core/pkg/buildmeta.BuildNumber=$BUILDNUMBER" -o /app -v ./...
+RUN go install github.com/DataDog/orchestrion@v1.5.0 \
+    && orchestrion pin \
+    && go mod tidy \
+    && go mod verify \
+    && go mod vendor \
+    && CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH GOFLAGS="${GOFLAGS} '-toolexec=orchestrion toolexec'" go build -ldflags "-X github.com/SneaksAndData/nexus-core/pkg/buildmeta.AppVersion=$APPVERSION -X github.com/SneaksAndData/nexus-core/pkg/buildmeta.BuildNumber=$BUILDNUMBER" -o /app -v ./...
 
 FROM --platform=$BUILDPLATFORM public.ecr.aws/amazonlinux/amazonlinux:2 AS aws-cli-stage
 

--- a/.helm/templates/deployment.yaml
+++ b/.helm/templates/deployment.yaml
@@ -101,6 +101,16 @@ spec:
                 fieldRef:
                   fieldPath: metadata.uid
           {{- end }}
+          {{- if .Values.datadog.tracer.enabled }}
+            - name: DD_INSTRUMENTATION_TELEMETRY_ENABLED
+              value: {{ .Values.datadog.tracer.disable_vendor_telemetry | quote }}
+            - name: DD_TRACE_ENABLED
+              value: {{ .Values.datadog.tracer.enabled | quote }}
+            - name: DD_TRACE_AGENT_URL
+              value: {{ .Values.datadog.tracer.agent_url | quote }}
+            - name: DD_ENV
+              value: {{ .Values.datadog.tracer.service_env | quote }}
+          {{- end }}
             - name: DATADOG__SERVICE_NAME
               value: {{ .Values.datadog.serviceName }}
             - name: DD_SERVICE

--- a/.helm/values.yaml
+++ b/.helm/values.yaml
@@ -297,4 +297,17 @@ datadog:
   
   # enables metric origin detection by setting DD_ENTITY_ID
   enableOriginDetection: true
-  
+
+  # Datadog tracing via Orchestrion
+  tracer:
+    # enable tracer
+    enabled: false
+
+    # UDS/HTTP url for the tracer
+    agent_url: unix:///var/run/datadog/apm.socket
+
+    # disable Datadog product info collection
+    disable_vendor_telemetry: true
+
+    # service environment tag
+    service_env: development


### PR DESCRIPTION
## Scope

- Support APM and tracing via Orchestrion

Note that Orchestrion is not added to the project, but instead installed and used at image build time. This is on purpose to keep application code as free as possible from whatever extra obs tooling is used.